### PR TITLE
Support Two-Track and Three-Track models

### DIFF
--- a/docs/content/a-tale-of-3-nightclubs-fsharp.fsx
+++ b/docs/content/a-tale-of-3-nightclubs-fsharp.fsx
@@ -10,7 +10,7 @@ This C# tutorial is based on a [Scalaz tutorial](https://gist.github.com/oxbowla
 Additional resources:
 
 * Railway Oriented Programming by Scott Wlaschin - A functional approach to error handling
-	* [Blog post](http://fsharpforfunandprofit.com/posts/recipe-part2/)
+  * [Blog post](http://fsharpforfunandprofit.com/posts/recipe-part2/)
     * [Slide deck](http://www.slideshare.net/ScottWlaschin/railway-oriented-programming)
     * [Video](https://vimeo.com/97344498)
 
@@ -49,17 +49,17 @@ module Club =
     let checkAge (p : Person) = 
         if p.Age < 18 then fail "Too young!"
         elif p.Age > 40 then fail "Too old!"
-        else ok p
+        else pass p
     
     let checkClothes (p : Person) = 
         if p.Gender = Male && not (p.Clothes.Contains "Tie") then fail "Smarten up!"
         elif p.Gender = Female && p.Clothes.Contains "Trainers" then fail "Wear high heels"
-        else ok p
+        else pass p
     
     let checkSobriety (p : Person) = 
         match p.Sobriety with
         | Drunk | Paralytic | Unconscious -> fail "Sober up!"
-        | _ -> ok p
+        | _ -> pass p
 
 (**
 ## Part One : Clubbed to Death

--- a/docs/content/pass-warn-fail.fsx
+++ b/docs/content/pass-warn-fail.fsx
@@ -61,10 +61,10 @@ let checkApplicant request =
 
 let processRequest request = 
   match checkApplicant request with
-  | Pass  _       ->  printfn "All Good!!!"
-  | Warn (_,log)  ->  printfn "Got some issues:"
-                      for msg in log do printfn "  %s" msg
-  | _             ->  printfn "Something went horribly wrong."
+  | Pass _    ->  printfn "All Good!!!"
+  | Warn log  ->  printfn "Got some issues:"
+                  for msg in log do printfn "  %s" msg
+  | _         ->  printfn "Something went horribly wrong."
 
             
 // good request
@@ -100,7 +100,7 @@ let recheckApplicant request =
 let reportMessages request =
   match recheckApplicant request with
   | Pass  _       ->  printfn "Nothing to report"
-  | Warn (_,log)  ->  printfn "Got some issues:"
+  | Warn log      ->  printfn "Got some issues:"
                       for msg in log do printfn "  %s" msg
   | Fail  errors  ->  printfn "Got errors:"
                       for msg in errors do printfn "  %s" msg
@@ -144,7 +144,7 @@ let ``processRequest (again)`` request =
   // turn any warning messages into failure messages
   let result =  request
                 |> ``checkApplicant (again)``
-                |> failOnWarnings
+                |> failOnWarnings id
   // now we only have 2 tracks on which the data may lay
   match result with
   | Fail errors ->  for x in errors do printfn "ERROR! %s" x

--- a/docs/content/railway.fsx
+++ b/docs/content/railway.fsx
@@ -32,19 +32,19 @@ type Request =
 let validateInput input = 
     if input.Name = "" then fail "Name must not be blank"
     elif input.EMail = "" then fail "Email must not be blank"
-    else ok input // happy path
+    else pass input // happy path
 
 let validate1 input = 
     if input.Name = "" then fail "Name must not be blank"
-    else ok input
+    else pass input
 
 let validate2 input = 
     if input.Name.Length > 50 then fail "Name must not be longer than 50 chars"
-    else ok input
+    else pass input
 
 let validate3 input = 
     if input.EMail = "" then fail "Email must not be blank"
-    else ok input
+    else pass input
 
 let combinedValidation = 
     // connect the two-tracks together
@@ -74,7 +74,7 @@ let combinedValidation =
 
 { Name = "Scott"; EMail = "scott@chessie.com" }
 |> combinedValidation
-|> returnOrFail
+|> returnOrRaise
 // [fsi:val it : Request = {Name = "Scott"; EMail = "scott@chessie.com";}]
 
 
@@ -82,11 +82,11 @@ let canonicalizeEmail input = { input with EMail = input.EMail.Trim().ToLower() 
 
 let usecase = 
     combinedValidation
-    >> (lift canonicalizeEmail)
+    >> (map canonicalizeEmail)
 
 { Name = "Scott"; EMail = "SCOTT@CHESSIE.com" }
 |> usecase
-|> returnOrFail
+|> returnOrRaise
 // [fsi:val it : Request = {Name = "Scott"; EMail = "scott@chessie.com";}]
 
 { Name = ""; EMail = "SCOTT@CHESSIE.com" }
@@ -105,13 +105,13 @@ let log twoTrackInput =
 
 let usecase2 = 
     usecase
-    >> (successTee updateDatabase)
+    >> (passTee updateDatabase)
     >> log
 
 
 { Name = "Scott"; EMail = "SCOTT@CHESSIE.com" }
 |> usecase2
-|> returnOrFail
+|> returnOrRaise
 // [fsi:DEBUG. Success so far.]
 // [fsi:val it : Request = {Name = "Scott";]
 // [fsi:                    EMail = "scott@chessie.com";}]

--- a/src/Chessie/AssemblyInfo.fs
+++ b/src/Chessie/AssemblyInfo.fs
@@ -4,9 +4,9 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("Chessie")>]
 [<assembly: AssemblyProductAttribute("Chessie")>]
 [<assembly: AssemblyDescriptionAttribute("Railway-oriented programming for .NET")>]
-[<assembly: AssemblyVersionAttribute("0.0.23")>]
-[<assembly: AssemblyFileVersionAttribute("0.0.23")>]
+[<assembly: AssemblyVersionAttribute("0.2.0")>]
+[<assembly: AssemblyFileVersionAttribute("0.2.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.0.23"
+    let [<Literal>] Version = "0.2.0"

--- a/src/Chessie/ErrorHandling.fs
+++ b/src/Chessie/ErrorHandling.fs
@@ -382,10 +382,9 @@ type OutcomeExtensions =
   static member SelectMany  (this     :Outcome<'Success,'Message>
                             ,withPass :Func<_,_>
                             ,selector :Func<_,_,_>) =
-    //TODO: this method is almost certainly wrong!
     match this with
     | Pass (v1,_)   ->  match withPass.Invoke v1 with
-                        | Pass (v2,_)   ->  selector.Invoke (v1,v2)
+                        | Pass (v2,_)   ->  pass <| selector.Invoke (v1,v2)
                         | Fail failure  ->  Fail failure
     | Fail failure  ->                      Fail failure
 

--- a/tests/Chessie.CSharp.Test/NightClubsValidation.cs
+++ b/tests/Chessie.CSharp.Test/NightClubsValidation.cs
@@ -63,11 +63,10 @@ namespace Chessie.CSharp.Test
   {
     public static Outcome<decimal,string> CostToEnter (Person p)
     {
-      return Outcome.PassWith<decimal,string>(0m);
-      //return from a in Club.CheckAge (p)
-      //       from b in Club.CheckClothes(a)
-      //       from c in Club.CheckSobriety (b)
-      //       select c.Gender == Gender.Female ? 0m : 5m;
+      return from a in Club.CheckAge (p)
+             from b in Club.CheckClothes(a)
+             from c in Club.CheckSobriety (b)
+             select c.Gender == Gender.Female ? 0m : 5m;
     }
   }
 

--- a/tests/Chessie.CSharp.Test/NightClubsValidation.cs
+++ b/tests/Chessie.CSharp.Test/NightClubsValidation.cs
@@ -1,5 +1,5 @@
 ﻿using Chessie.ErrorHandling;
-using Chessie.ErrorHandling.CSharp;
+using Chessie.ErrorHandling.Compat;
 using Microsoft.FSharp.Collections;
 using NUnit.Framework;
 using System;
@@ -10,109 +10,110 @@ using System.Threading.Tasks;
 
 namespace Chessie.CSharp.Test
 {
-    // originally from https://github.com/fsprojects/fsharpx/blob/master/tests/FSharpx.CSharpTests/ValidationExample.cs
+  // originally from https://github.com/fsprojects/fsharpx/blob/master/tests/FSharpx.CSharpTests/ValidationExample.cs
 
-    enum Sobriety { Sober, Tipsy, Drunk, Paralytic, Unconscious }
-    enum Gender { Male, Female }
+  enum Sobriety { Sober, Tipsy, Drunk, Paralytic, Unconscious }
+  enum Gender { Male, Female }
 
-    class Person
+  class Person
+  {
+    public Gender Gender { get; private set; }
+    public int Age { get; private set; }
+    public List<string> Clothes { get; private set; }
+    public Sobriety Sobriety { get; private set; }
+
+    public Person (Gender gender,int age,List<string> clothes,Sobriety sobriety)
     {
-        public Gender Gender { get; private set; }
-        public int Age { get; private set; }
-        public List<string> Clothes { get; private set; }
-        public Sobriety Sobriety { get; private set; }
+      this.Gender = gender;
+      this.Age = age;
+      this.Clothes = clothes;
+      this.Sobriety = sobriety;
+    }
+  }
 
-        public Person(Gender gender, int age, List<string> clothes, Sobriety sobriety)
-        {
-            this.Gender = gender;
-            this.Age = age;
-            this.Clothes = clothes;
-            this.Sobriety = sobriety;
-        }
+  class Club
+  {
+    public static Outcome<Person,string> CheckAge (Person p)
+    {
+      if (p.Age < 18)
+        return Outcome.FailWith<Person,string> ("Too young!");
+      if (p.Age > 40)
+        return Outcome.FailWith<Person,string> ("Too old!");
+      return Outcome.PassWith<Person,string> (p);
     }
 
-    class Club
+    public static Outcome<Person,string> CheckClothes (Person p)
     {
-        public static Result<Person, string> CheckAge(Person p)
-        {
-            if (p.Age < 18)
-                return Result<Person, string>.FailWith("Too young!");
-            if (p.Age > 40)
-                return Result<Person, string>.FailWith("Too old!");
-            return Result<Person, string>.Succeed(p);
-        }
-
-        public static Result<Person, string> CheckClothes(Person p)
-        {
-            if (p.Gender == Gender.Male && !p.Clothes.Contains("Tie"))
-                return Result<Person, string>.FailWith("Smarten up!");
-            if (p.Gender == Gender.Female && p.Clothes.Contains("Trainers"))
-                return Result<Person, string>.FailWith("Wear high heels!");
-            return Result<Person, string>.Succeed(p);
-        }
-
-        public static Result<Person, string> CheckSobriety(Person p)
-        {
-            if (new[] { Sobriety.Drunk, Sobriety.Paralytic, Sobriety.Unconscious }.Contains(p.Sobriety))
-                return Result<Person, string>.FailWith("Sober up!");
-            return Result<Person, string>.Succeed(p);
-        }
+      if (p.Gender == Gender.Male && !p.Clothes.Contains ("Tie"))
+        return Outcome.FailWith<Person,string> ("Smarten up!");
+      if (p.Gender == Gender.Female && p.Clothes.Contains ("Trainers"))
+        return Outcome.FailWith<Person,string> ("Wear high heels!");
+      return Outcome.PassWith<Person,string> (p);
     }
 
-    class ClubbedToDeath
+    public static Outcome<Person,string> CheckSobriety (Person p)
     {
-        public static Result<decimal, string> CostToEnter(Person p)
-        {
-            return from a in Club.CheckAge(p)
-                   from b in Club.CheckClothes(a)
-                   from c in Club.CheckSobriety(b)
-                   select c.Gender == Gender.Female ? 0m : 5m;
-        }
+      if (new[] { Sobriety.Drunk,Sobriety.Paralytic,Sobriety.Unconscious }.Contains (p.Sobriety))
+        return Outcome.FailWith<Person,string> ("Sober up!");
+      return Outcome.PassWith<Person,string> (p);
     }
+  }
 
-    [TestFixture]
-    class Test1
+  class ClubbedToDeath
+  {
+    public static Outcome<decimal,string> CostToEnter (Person p)
     {
-        [Test]
-        public void Part1()
-        {
-            var Dave = new Person(Gender.Male, 41, new List<string> { "Tie", "Jeans" }, Sobriety.Sober);
-            var costDave = ClubbedToDeath.CostToEnter(Dave);
-            Assert.AreEqual("Too old!", costDave.FailedWith().First());
-
-            var Ken = new Person(Gender.Male, 28, new List<string> { "Tie", "Shirt" }, Sobriety.Tipsy);
-            var costKen = ClubbedToDeath.CostToEnter(Ken);
-            Assert.AreEqual(5m, costKen.SucceededWith());
-
-            var Ruby = new Person(Gender.Female, 25, new List<string> { "High heels" }, Sobriety.Tipsy);
-            var costRuby = ClubbedToDeath.CostToEnter(Ruby);
-            costRuby.Match(
-                (x, msgs) =>
-                {
-                    Assert.AreEqual(0m, x);
-                },
-                msgs =>
-                {
-                    Assert.Fail();
-
-                });
-
-            var Ruby17 = new Person(Ruby.Gender, 17, Ruby.Clothes, Ruby.Sobriety);
-            var costRuby17 = ClubbedToDeath.CostToEnter(Ruby17);
-            Assert.AreEqual("Too young!", costRuby17.FailedWith().First());
-
-            var KenUnconscious = new Person(Ken.Gender, Ken.Age, Ken.Clothes, Sobriety.Unconscious);
-            var costKenUnconscious = ClubbedToDeath.CostToEnter(KenUnconscious);
-            costKenUnconscious.Match(
-                (x, msgs) =>
-                {
-                    Assert.Fail();
-                },
-                msgs =>
-                {
-                    Assert.AreEqual("Sober up!", msgs.First());
-                });
-        }
+      return Outcome.PassWith<decimal,string>(0m);
+      //return from a in Club.CheckAge (p)
+      //       from b in Club.CheckClothes(a)
+      //       from c in Club.CheckSobriety (b)
+      //       select c.Gender == Gender.Female ? 0m : 5m;
     }
+  }
+
+  [TestFixture]
+  class Test1
+  {
+    [Test]
+    public void Part1 ()
+    {
+      var Dave = new Person (Gender.Male,41,new List<string> { "Tie","Jeans" },Sobriety.Sober);
+      var costDave = ClubbedToDeath.CostToEnter (Dave);
+      Assert.AreEqual ("Too old!",costDave.FailedWith ().First ());
+
+      var Ken = new Person (Gender.Male,28,new List<string> { "Tie","Shirt" },Sobriety.Tipsy);
+      var costKen = ClubbedToDeath.CostToEnter (Ken);
+      Assert.AreEqual (5m,costKen.SucceededWith ());
+
+      var Ruby = new Person (Gender.Female,25,new List<string> { "High heels" },Sobriety.Tipsy);
+      var costRuby = ClubbedToDeath.CostToEnter (Ruby);
+      costRuby.Match (
+          (x,msgs) =>
+          {
+            Assert.AreEqual (0m,x);
+          },
+          msgs =>
+          {
+            Assert.Fail ();
+
+          });
+
+      var Ruby17 = new Person (Ruby.Gender,17,Ruby.Clothes,Ruby.Sobriety);
+      var costRuby17 = ClubbedToDeath.CostToEnter (Ruby17);
+      Assert.AreEqual ("Too young!",costRuby17.FailedWith ().First ());
+
+      var KenUnconscious = new Person (Ken.Gender,Ken.Age,Ken.Clothes,Sobriety.Unconscious);
+      var costKenUnconscious = ClubbedToDeath.CostToEnter (KenUnconscious);
+      costKenUnconscious.Match (
+          (x,msgs) =>
+          {
+            Assert.Fail ();
+          },
+          msgs =>
+          {
+            Assert.AreEqual ("Sober up!",msgs.First ());
+          });
+    }
+  }
 }
 

--- a/tests/Chessie.CSharp.Test/SimpleValidation.cs
+++ b/tests/Chessie.CSharp.Test/SimpleValidation.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Chessie.ErrorHandling;
-using Chessie.ErrorHandling.CSharp;
+using Chessie.ErrorHandling.Compat;
 
 namespace Chessie.CSharp.Test
 {
@@ -17,14 +17,13 @@ namespace Chessie.CSharp.Test
 
     public class Validation
     {
-        public static Result<Request, string> ValidateInput(Request input)
+        public static Outcome<Request, string> ValidateInput(Request input)
         {
             if (input.Name == "")
-                return Result<Request, string>.FailWith("Name must not be blank");
+              return Outcome.FailWith<Request,string>("Name must not be blank");
             if (input.EMail == "")
-                return Result<Request, string>.FailWith("Email must not be blank");
-            return Result<Request, string>.Succeed(input);
-
+              return Outcome.FailWith<Request,string>("Email must not be blank");
+            return Outcome.PassWith<Request,string>(input);
         }
     }
 
@@ -35,14 +34,14 @@ namespace Chessie.CSharp.Test
         public void TryWillCatch()
         {
             var exn = new Exception("Hello World");
-            var result = Result<string, Exception>.Try(() => { throw exn; });
+            var result = Outcome.Try<string>(() => { throw exn; });
             Assert.AreEqual(exn, result.FailedWith().First());
         }
 
         [Test]
         public void TryWillReturnValue()
         {
-            var result = Result<string, Exception>.Try(() => { return "hello world"; });
+            var result = Outcome.Try(() => { return "hello world"; });
             Assert.AreEqual("hello world", result.SucceededWith());
         }
     }
@@ -79,7 +78,7 @@ namespace Chessie.CSharp.Test
             var result = Validation.ValidateInput(request);
             result.Match(
                (x, msgs) => { throw new Exception("wrong match case"); },
-               msgs => { Assert.AreEqual("Email must not be blank", msgs[0]); });
+               msgs => { Assert.AreEqual("Email must not be blank", msgs.First()); });
         }
     }
 
@@ -107,7 +106,7 @@ namespace Chessie.CSharp.Test
                Validation.ValidateInput(request)
                 .Either(
                    (x, msgs) => { throw new Exception("wrong match case"); },
-                   msgs => { return msgs[0]; });
+                   msgs => { return msgs.First(); });
 
             Assert.AreEqual("Email must not be blank", result);
         }

--- a/tests/Chessie.Tests/BuilderTests.fs
+++ b/tests/Chessie.Tests/BuilderTests.fs
@@ -9,21 +9,21 @@ open System
 let ``Using CE syntax should be equivilent to bind`` () =
     let sut =
         trial {
-            let! bob = ok "bob"
+            let! bob = pass "bob"
             let greeting = sprintf "Hello %s" bob
             return greeting
         }
-    sut |> shouldEqual (bind (sprintf "Hello %s" >> ok) (ok "bob"))
+    sut |> shouldEqual (bind (sprintf "Hello %s" >> pass) (pass "bob"))
 
 [<Test>]
 let ``You should be able to "combine" in CE syntax`` () =
     let sut =
         trial {
             if "bob" = "bob" then
-                do! ok ()
+                do! pass ()
             return "bob"
         }
-    sut |> shouldEqual (ok "bob")
+    sut |> shouldEqual (pass "bob")
 
 [<Test>]
 let ``Try .. with works in CE syntax`` () =
@@ -36,7 +36,7 @@ let ``Try .. with works in CE syntax`` () =
                 with
                 | e -> e.Message
         }
-    sut |> shouldEqual (ok "bang")
+    sut |> shouldEqual (pass "bang")
 
 [<Test>]
 let ``Try .. finally works in CE syntax`` () =
@@ -49,8 +49,8 @@ let ``Try .. finally works in CE syntax`` () =
                 i := 1
         }
     with
-    | e -> ok ()
-    |> returnOrFail
+    | e -> pass ()
+    |> returnOrRaise
     !i |> shouldEqual 1
 
 [<Test>]
@@ -58,12 +58,12 @@ let ``use! works in CE expressions`` () =
     use mem = new IO.MemoryStream()
     try
         trial {
-            use! mem = ok <| new IO.StreamReader(mem)
+            use! mem = pass <| new IO.StreamReader(mem)
             failwith "bang"
         }
     with
-    | e -> ok ()
-    |> returnOrFail
+    | e -> pass ()
+    |> returnOrRaise
     (fun () -> mem.ReadByte() |> ignore) |> shouldFail<ObjectDisposedException>
     
 [<Test>]
@@ -73,7 +73,7 @@ let ``While works in CE syntax`` () =
         while !i < 3 do
             i := !i + 1
     }
-    |> returnOrFail
+    |> returnOrRaise
     !i |> shouldEqual 3
 
 [<Test>]
@@ -83,5 +83,5 @@ let ``For works in CE syntax`` () =
         for x in 0..2 do
             i := !i + x
     }
-    |> returnOrFail
+    |> returnOrRaise
     !i |> shouldEqual 3

--- a/tests/Chessie.Tests/NightClubs.fs
+++ b/tests/Chessie.Tests/NightClubs.fs
@@ -26,17 +26,17 @@ module Club =
     let checkAge (p : Person) = 
         if p.Age < 18 then fail "Too young!"
         elif p.Age > 40 then fail "Too old!"
-        else ok p
+        else pass p
     
     let checkClothes (p : Person) = 
         if p.Gender = Male && not (p.Clothes.Contains "Tie") then fail "Smarten up!"
         elif p.Gender = Female && p.Clothes.Contains "Trainers" then fail "Wear high heels"
-        else ok p
+        else pass p
     
     let checkSobriety (p : Person) = 
         match p.Sobriety with
         | Drunk | Paralytic | Unconscious -> fail "Sober up!"
-        | _ -> ok p
+        | _ -> pass p
 
 module ClubbedToDeath =
     open Club
@@ -59,7 +59,7 @@ let Ruby = { Person.Gender = Female; Age = 25; Clothes = set ["High heels"]; Sob
 [<Test>]
 let part1() =
     ClubbedToDeath.costToEnter Dave |> shouldEqual (fail "Too old!")
-    ClubbedToDeath.costToEnter Ken |> shouldEqual (ok 5m)
-    ClubbedToDeath.costToEnter Ruby |> shouldEqual (ok 0m)
+    ClubbedToDeath.costToEnter Ken |> shouldEqual (pass 5m)
+    ClubbedToDeath.costToEnter Ruby |> shouldEqual (pass 0m)
     ClubbedToDeath.costToEnter { Ruby with Age = 17 } |> shouldEqual (fail "Too young!")
     ClubbedToDeath.costToEnter { Ken with Sobriety = Unconscious } |> shouldEqual (fail "Sober up!")


### PR DESCRIPTION
This is a very heavily refactored version of the Chessie code base, which is mostly the result of the discussion around issue #17. It attempts to make palatable, simultaneously, two-track and three-track models of error handling (or validation or logging or whatever). It also heavily incorporates the ideas expressed by Scott Wlaschin [here](http://fsharpforfunandprofit.com/posts/recipe-part2/). It is not really 100% complete. But it is of sufficient quality that others might understand the direction and improve upon it (or discard it entirely). In particular, none of the async code has been touched, as I really don't understand the problems it's trying to solve. Also, none of the code has been profiled and/or tweaked for performance. Additionally, at the moment, some of the ProjectScaffold components are failing on both Windows (running NUnit from FAKE) and OS X (running FSharp.Formatting). Oh, and it needs better docs, too.  

:-)
