### PR TITLE
SelectMany implementation changed, fixes #26

### DIFF
--- a/src/Chessie/ErrorHandling.fs
+++ b/src/Chessie/ErrorHandling.fs
@@ -335,9 +335,7 @@ type ResultExtensions () =
     /// Otherwise the exisiting failure is propagated.
     [<Extension>]
     static member inline SelectMany (this:Result<'TSuccess, 'TMessage>, func: Func<_,_>, mapper: Func<_,_,_>) =
-        let mapper = lift2 (fun a b -> mapper.Invoke(a,b))
-        let v = bind func.Invoke this
-        mapper this v
+        bind (fun s -> s |> func.Invoke |> lift (fun v -> mapper.Invoke(s,v))) this
 
     /// Lifts a Func into a Result and applies it on the given result.
     [<Extension>]

--- a/tests/Chessie.CSharp.Test/ExtensionsTests.cs
+++ b/tests/Chessie.CSharp.Test/ExtensionsTests.cs
@@ -20,9 +20,43 @@ namespace Chessie.CSharp.Test
                 ifSuccess: (x, msgs) =>
                 {
                     Assert.AreEqual(3, x);
-                    Assert.That(msgs, Is.EquivalentTo(new[] {"added one", "added two"}));
+                    Assert.That(msgs, Is.EquivalentTo(new[] { "added one", "added two" }));
                 },
                 ifFailure: errs => Assert.Fail());
+        }
+
+        [Test]
+        public void Test()
+        {
+            Func<Result<string, string>, Result<string, string>, Result<string, string>, Result<string, string>> f = (r1, r2, r3) =>
+                from a in r1
+                from b in r2
+                from c in r3
+                select a + b + c;
+
+            f(Result<string, string>.Succeed("1"), Result<string, string>.Succeed("2"), Result<string, string>.Succeed("3")).Match(
+                ifSuccess: (s, _) => Assert.That(s, Is.EqualTo("123")),
+                ifFailure: _ => Assert.Fail("should not fail"));
+
+            f(Result<string, string>.Succeed("1", "msg1"), Result<string, string>.Succeed("2", "msg2"), Result<string, string>.Succeed("3", "msg3")).Match(
+                ifSuccess: (s, list) =>
+                {
+                    Assert.That(s, Is.EqualTo("123"));
+                    Assert.That(list, Is.EquivalentTo(new[] {"msg1", "msg2", "msg3"}));
+                },
+                ifFailure: list => Assert.Fail("should not fail"));
+
+            f(Result<string, string>.FailWith("fail"), Result<string, string>.Succeed("2"), Result<string, string>.Succeed("3")).Match(
+                ifSuccess: (s, _) => Assert.Fail("should fail"),
+                ifFailure: list => Assert.That(list, Is.EquivalentTo(new[] { "fail" })));
+
+            f(Result<string, string>.Succeed("1"), Result<string, string>.FailWith("fail"), Result<string, string>.Succeed("3")).Match(
+                ifSuccess: (s, _) => Assert.Fail("should fail"),
+                ifFailure: list => Assert.That(list, Is.EquivalentTo(new[] { "fail" })));
+
+            f(Result<string, string>.Succeed("1"), Result<string, string>.FailWith("fail1"), Result<string, string>.FailWith("fail2")).Match(
+                ifSuccess: (s, _) => Assert.Fail("should fail"),
+                ifFailure: list => Assert.That(list, Is.EquivalentTo(new[] { "fail1" })));
         }
     }
 }


### PR DESCRIPTION
This fixes #26.

The C# LINQ query syntax `from a in ... select ...` should do a bind operation. This was currently not working correctly as messages where being repeated.

E.g.

```
from a in Result<string, string>.FailWith("fail1")
from b in Result<string, string>.FailWith("fail2")
from c in Result<string, string>.FailWith("fail3")
select new[] { a, b, c }
```

produces now a Failure with exactly 1 message: `< "fail1" >` instead of 4 duplicated messages.
