### PR TITLE
Added a function and C# extension method for mapping over the failure type

### DIFF
--- a/src/Chessie/ErrorHandling.fs
+++ b/src/Chessie/ErrorHandling.fs
@@ -114,6 +114,12 @@ module Trial =
     /// Lifts a function into a Result container and applies it on the given result.
     let inline lift f result = apply (ok f) result
 
+    /// Maps a function over the existing error messages in case of failure. In case of success, the message type will be changed and warnings will be discarded.
+    let inline mapFailure f result =
+        match result with
+        | Ok (v,_) -> ok v
+        | Bad errs -> Bad (f errs)
+
     /// Lifts a function into a Result and applies it on the given result.
     /// This is the infix operator version of ErrorHandling.lift
     let inline (<!>) f result = lift f result
@@ -371,3 +377,8 @@ type ResultExtensions () =
         curry resultSelector.Invoke
         <!> this 
         <*> inner
+
+    /// Maps a function over the existing error messages in case of failure. In case of success, the message type will be changed and warnings will be discarded.
+    [<Extension>]
+    static member inline MapFailure (this: Result<'TSuccess, 'TMessage>, f: Func<'TMessage list, 'TMessage2 seq>) =
+        this |> Trial.mapFailure (f.Invoke >> Seq.toList)

--- a/tests/Chessie.Tests/TrialTests.fs
+++ b/tests/Chessie.Tests/TrialTests.fs
@@ -21,3 +21,33 @@ let ``ofChoice if Choice2Of2 of list it should fail`` () =
     let choice = Choice2Of2 ["error1";"error2"]
     let result = choice |> Trial.ofChoice
     result |> shouldEqual (fail ["error1";"error2"])
+
+[<Test>]
+let ``mapFailure if success should discard warning`` () =
+    Ok (42,[1;2;3])
+    |> Trial.mapFailure (fun _ -> ["err1"])
+    |> shouldEqual (Ok (42,[]))
+
+[<Test>]
+let ``mapFailure if failure should map over error`` () =
+    fail "error"
+    |> Trial.mapFailure (fun _ -> [42])
+    |> shouldEqual (Bad [42])
+
+[<Test>]
+let ``mapFailure if failure should map over list of errors`` () =
+    Bad ["err1"; "err2"]
+    |> Trial.mapFailure (fun errs -> errs |> List.map (function "err1" -> 42 | "err2" -> 43 | _ -> 0))
+    |> shouldEqual (Bad [42; 43])
+
+[<Test>]
+let ``mapFailure if failure should replace errors with singleton list`` () =
+    Bad ["err1", "err2"]
+    |> Trial.mapFailure (fun _ -> [42])
+    |> shouldEqual (Bad [42])
+
+[<Test>]
+let ``mapFailure if failure should map over empty list of errors`` () =
+    Bad []
+    |> Trial.mapFailure (fun errs -> errs |> List.map (function "err1" -> 42 | "err2" -> 43 | _ -> 0))
+    |> shouldEqual (Bad [])


### PR DESCRIPTION
`mapFailure` maps a function over the existing error messages in case of failure. In case of success, the message type will be changed and warnings will be discarded.

This is handy when we get a Result from another domain and we want to convert it to be compatible with our domain message type.

It is also helpful when we convert a Choice into a Result to match the type of Choice2Of2 with our domain message type.
