### PR TITLE
added fsharp friendly version of try called tryCatch

### DIFF
--- a/src/Chessie/ErrorHandling.fs
+++ b/src/Chessie/ErrorHandling.fs
@@ -53,6 +53,9 @@ module Trial =
     /// Wraps a message in a Failure
     let inline fail<'TSuccess,'Message> (msg:'Message) : Result<'TSuccess,'Message> = Bad([ msg ])
 
+    /// Executes the given function on a given success or captures the exception in a failure
+    let inline tryCatch f x = Result<_,_>.Try(fun () -> f x)
+
     /// Returns true if the result was not successful.
     let inline failed result = 
         match result with
@@ -90,7 +93,7 @@ module Trial =
 
    /// Flattens a nested result given the Failure types are equal
     let inline flatten (result : Result<Result<_,_>,_>) =
-        result |> bind (fun x -> x)
+        result |> bind id
 
     /// If the result is a Success it executes the given function on the value. 
     /// Otherwise the exisiting failure is propagated.

--- a/tests/Chessie.Tests/TrialTests.fs
+++ b/tests/Chessie.Tests/TrialTests.fs
@@ -51,3 +51,17 @@ let ``mapFailure if failure should map over empty list of errors`` () =
     Bad []
     |> Trial.mapFailure (fun errs -> errs |> List.map (function "err1" -> 42 | "err2" -> 43 | _ -> 0))
     |> shouldEqual (Bad [])
+
+[<Test>]
+let ``tryCatch if failure should return exception`` () = 
+    let ex = exn "error" 
+    1 
+    |> Trial.tryCatch (fun x -> raise ex) 
+    |> shouldEqual (Bad[ex])
+        
+
+[<Test>]
+let ``tryCatch if success should return list`` () = 
+    1 
+    |> Trial.tryCatch id 
+    |> shouldEqual (Ok(1,[]))


### PR DESCRIPTION
Sometimes you want to trap exceptions in F# code. Particularly when calling C# code from F#. I made an F# friendly version of Try named tryCatch.
