### PR TITLE
Netcore with dotnetcli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 *.user
 *.sln.docstates
 
+# .NET cli
+
+project.lock.json
+
 # Xamarin Studio / monodevelop user-specific
 *.userprefs
 

--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,7 @@ temp/
 
 # Test results produced by build
 TestResults.xml
+TestResult.xml
 
 # Nuget outputs
 nuget/*.nupkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,51 @@
 language: csharp
 
-sudo: false  # use the new container-based Travis infrastructure 
+#dotnet cli require Ubuntu 14.04
+sudo: required
+dist: trusty
+
+#dotnet cli require OSX 10.10
+osx_image: xcode7.1
+
+addons:
+  apt:
+    packages:
+    - gettext
+    - libcurl4-openssl-dev
+    - libicu-dev
+    - libssl-dev
+    - libunwind8
+    - zlib1g
+
+os:
+  - osx
+
+env:
+  - CLI_VERSION="1.0.0.001494"
+
+before_install:
+  # Download script to install dotnet cli
+  - curl -L --create-dirs https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.sh -o ./scripts/obtain/install.sh
+  - find ./scripts -name "*.sh" -exec chmod +x {} \;
+  # use bash to workaround bug https://github.com/dotnet/cli/issues/1725
+  - sudo bash ./scripts/obtain/install.sh --channel "beta" --version "$CLI_VERSION"
+  - which dotnet
 
 script: 
   - ./build.sh All
+  # Build .NET Core with .NET CLI
+  # Workaround fsc doesnt work
+  - if test "$TRAVIS_OS_NAME" == "osx"; then sudo curl -L -s https://github.com/enricosada/fsharp-dotnet-cli-samples/raw/master/workarounds/1/osx.10.10-x64.zip | tar xvf - -C /usr/local/share/dotnet/cli/bin/ ; fi
+  # Workaround "Too many open files"
+  - ulimit -n 1024
+  # cli 
+  - dotnet restore
+  # Build Chessie
+  - cd "$TRAVIS_BUILD_DIR/src/Chessie"
+  - dotnet --verbose build --framework dnxcore50
+  # Run tests (Chessie.Tests)
+  - cd "$TRAVIS_BUILD_DIR/tests/Chessie.Tests"
+  - dotnet --verbose run --framework dnxcore50
+  # Run tests (Chessie.CSharp.Test) 
+  - cd "$TRAVIS_BUILD_DIR/tests/Chessie.CSharp.Test"
+  - dotnet --verbose run --framework dnxcore50

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,28 +24,16 @@ env:
   - CLI_VERSION="1.0.0.001494"
 
 before_install:
-  # Download script to install dotnet cli
+  # Download script to install .NET CLI
   - curl -L --create-dirs https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.sh -o ./scripts/obtain/install.sh
   - find ./scripts -name "*.sh" -exec chmod +x {} \;
   # use bash to workaround bug https://github.com/dotnet/cli/issues/1725
   - sudo bash ./scripts/obtain/install.sh --channel "beta" --version "$CLI_VERSION"
   - which dotnet
-
-script: 
-  - ./build.sh All
-  # Build .NET Core with .NET CLI
   # Workaround fsc doesnt work
   - if test "$TRAVIS_OS_NAME" == "osx"; then sudo curl -L -s https://github.com/enricosada/fsharp-dotnet-cli-samples/raw/master/workarounds/1/osx.10.10-x64.zip | tar xvf - -C /usr/local/share/dotnet/cli/bin/ ; fi
   # Workaround "Too many open files"
   - ulimit -n 1024
-  # cli 
-  - dotnet restore
-  # Build Chessie
-  - cd "$TRAVIS_BUILD_DIR/src/Chessie"
-  - dotnet --verbose build --framework dnxcore50
-  # Run tests (Chessie.Tests)
-  - cd "$TRAVIS_BUILD_DIR/tests/Chessie.Tests"
-  - dotnet --verbose run --framework dnxcore50
-  # Run tests (Chessie.CSharp.Test) 
-  - cd "$TRAVIS_BUILD_DIR/tests/Chessie.CSharp.Test"
-  - dotnet --verbose run --framework dnxcore50
+
+script: 
+  - ./build.sh All

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,19 +21,22 @@ os:
   - osx
 
 env:
-  - CLI_VERSION="1.0.0.001494"
+  - CLI_VERSION="1.0.0-beta-002071"
 
 before_install:
-  # Download script to install .NET CLI
-  - curl -L --create-dirs https://raw.githubusercontent.com/dotnet/cli/834edfbc9ccbe2dbe63b89a8d09c4199d000da38/scripts/obtain/install.sh -o ./scripts/obtain/install.sh
+  # Download script to install dotnet cli
+  - curl -L --create-dirs https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.sh -o ./scripts/obtain/install.sh
   - find ./scripts -name "*.sh" -exec chmod +x {} \;
+  - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
   # use bash to workaround bug https://github.com/dotnet/cli/issues/1725
-  - sudo bash ./scripts/obtain/install.sh --channel "beta" --version "$CLI_VERSION"
-  - which dotnet
-  # Workaround fsc doesnt work
-  - if test "$TRAVIS_OS_NAME" == "osx"; then sudo curl -L -s https://github.com/enricosada/fsharp-dotnet-cli-samples/raw/master/workarounds/1/osx.10.10-x64.zip | tar xvf - -C /usr/local/share/dotnet/cli/bin/ ; fi
+  - sudo bash ./scripts/obtain/install.sh --channel "preview" --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR" --no-path
+  # add dotnet to PATH
+  - export PATH="$DOTNET_INSTALL_DIR:$PATH"
   # Workaround "Too many open files"
   - ulimit -n 1024
+  # show dotnet info
+  - which dotnet
+  - dotnet --info
 
 script: 
   - ./build.sh All

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
 
 before_install:
   # Download script to install .NET CLI
-  - curl -L --create-dirs https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.sh -o ./scripts/obtain/install.sh
+  - curl -L --create-dirs https://raw.githubusercontent.com/dotnet/cli/834edfbc9ccbe2dbe63b89a8d09c4199d000da38/scripts/obtain/install.sh -o ./scripts/obtain/install.sh
   - find ./scripts -name "*.sh" -exec chmod +x {} \;
   # use bash to workaround bug https://github.com/dotnet/cli/issues/1725
   - sudo bash ./scripts/obtain/install.sh --channel "beta" --version "$CLI_VERSION"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,22 +17,6 @@ install:
 
 build_script:
   - cmd: build.cmd
-  # Build .NET Core with .NET CLI
-  - ps: dotnet restore
-  # Build Chessie
-  - ps: cd "$env:APPVEYOR_BUILD_FOLDER\src\Chessie"
-  - ps: dotnet --verbose build
-  # Run tests (Chessie.Tests)
-  - ps: cd "$env:APPVEYOR_BUILD_FOLDER\tests\Chessie.Tests"
-  - ps: dotnet --verbose run --framework net46
-  - ps: dotnet --verbose run --framework dnxcore50
-  # Run tests (Chessie.CSharp.Test) 
-  - ps: cd "$env:APPVEYOR_BUILD_FOLDER\tests\Chessie.CSharp.Test"
-  - ps: dotnet --verbose run --framework net46
-  - ps: dotnet --verbose run --framework dnxcore50
-  # crate package
-  - ps: cd "$env:APPVEYOR_BUILD_FOLDER\src\Chessie"
-  - ps: dotnet pack --configuration Release
 
 test: off
 version: 0.0.1.{build}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 install:
   # Download install script to install .NET cli in .dotnet dir
   - ps: mkdir -Force ".\scripts\obtain\" | Out-Null
-  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.ps1" -OutFile ".\scripts\obtain\install.ps1"
+  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/834edfbc9ccbe2dbe63b89a8d09c4199d000da38/scripts/obtain/install.ps1" -OutFile ".\scripts\obtain\install.ps1"
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnet"
   - ps: '& .\scripts\obtain\install.ps1 -Channel "beta" -version "$env:CLI_VERSION"'
   # set DOTNET_HOME env var and add dotnet bin to PATH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,43 @@
 init:
   - git config --global core.autocrlf input
+
+environment:
+  CLI_VERSION: 1.0.0.001494
+
+install:
+  # Download install script to install .NET cli in .dotnet dir
+  - ps: mkdir -Force ".\scripts\obtain\" | Out-Null
+  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.ps1" -OutFile ".\scripts\obtain\install.ps1"
+  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnet"
+  - ps: '& .\scripts\obtain\install.ps1 -Channel "beta" -version "$env:CLI_VERSION"'
+  # set DOTNET_HOME env var and add dotnet bin to PATH
+  - ps: $env:DOTNET_HOME = "$env:DOTNET_INSTALL_DIR\cli\bin"
+  - ps: $env:Path = "$env:DOTNET_HOME;$env:Path"
+  - ps: 'echo "Dotnet: $( (gcm dotnet).Path )"'
+
 build_script:
   - cmd: build.cmd
+  # Build .NET Core with .NET CLI
+  - ps: dotnet restore
+  # Build Chessie
+  - ps: cd "$env:APPVEYOR_BUILD_FOLDER\src\Chessie"
+  - ps: dotnet --verbose build
+  # Run tests (Chessie.Tests)
+  - ps: cd "$env:APPVEYOR_BUILD_FOLDER\tests\Chessie.Tests"
+  - ps: dotnet --verbose run --framework net46
+  - ps: dotnet --verbose run --framework dnxcore50
+  # Run tests (Chessie.CSharp.Test) 
+  - ps: cd "$env:APPVEYOR_BUILD_FOLDER\tests\Chessie.CSharp.Test"
+  - ps: dotnet --verbose run --framework net46
+  - ps: dotnet --verbose run --framework dnxcore50
+  # crate package
+  - ps: cd "$env:APPVEYOR_BUILD_FOLDER\src\Chessie"
+  - ps: dotnet pack --configuration Release
+
 test: off
 version: 0.0.1.{build}
 artifacts:
   - path: bin
     name: bin
+  - path: src\Chessie\bin\Release
+    name: netcore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,18 +2,19 @@ init:
   - git config --global core.autocrlf input
 
 environment:
-  CLI_VERSION: 1.0.0.001494
+  CLI_VERSION: 1.0.0-beta-002071
 
 install:
   # Download install script to install .NET cli in .dotnet dir
   - ps: mkdir -Force ".\scripts\obtain\" | Out-Null
-  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/834edfbc9ccbe2dbe63b89a8d09c4199d000da38/scripts/obtain/install.ps1" -OutFile ".\scripts\obtain\install.ps1"
-  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnet"
-  - ps: '& .\scripts\obtain\install.ps1 -Channel "beta" -version "$env:CLI_VERSION"'
-  # set DOTNET_HOME env var and add dotnet bin to PATH
-  - ps: $env:DOTNET_HOME = "$env:DOTNET_INSTALL_DIR\cli\bin"
-  - ps: $env:Path = "$env:DOTNET_HOME;$env:Path"
+  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.ps1" -OutFile ".\scripts\obtain\install.ps1"
+  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
+  - ps: '& .\scripts\obtain\install.ps1 -Channel "preview" -version "$env:CLI_VERSION" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath'
+  # add dotnet to PATH
+  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+  # show dotnet info
   - ps: 'echo "Dotnet: $( (gcm dotnet).Path )"'
+  - ps: dotnet --info
 
 build_script:
   - cmd: build.cmd
@@ -23,5 +24,3 @@ version: 0.0.1.{build}
 artifacts:
   - path: bin
     name: bin
-  - path: src\Chessie\bin\Release
-    name: netcore

--- a/build.fsx
+++ b/build.fsx
@@ -331,7 +331,7 @@ Target "BuildPackage" DoNothing
 // .NET CLI and .NET Core
 
 let assertExitCodeZero x = if x = 0 then () else failwithf "Command failed with exit code %i" x
-let netcoreFW = "dnxcore50"
+let netcoreFW = "netstandard1.5"
 
 Target "DotnetCliBuild" (fun _ ->
     Shell.Exec("dotnet", "restore") |> assertExitCodeZero

--- a/global.json
+++ b/global.json
@@ -1,0 +1,3 @@
+{
+  "projects": [ "src", "tests" ]
+}

--- a/src/Chessie/NuGet.Config
+++ b/src/Chessie/NuGet.Config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Chessie/Program.fs
+++ b/src/Chessie/Program.fs
@@ -1,0 +1,9 @@
+﻿// Learn more about F# at http://fsharp.org
+
+open System
+
+[<EntryPoint>]
+let main argv = 
+    printfn "Hello World!"
+    printfn "%A" argv
+    0 // return an integer exit code

--- a/src/Chessie/Program.fs
+++ b/src/Chessie/Program.fs
@@ -1,9 +1,0 @@
-﻿// Learn more about F# at http://fsharp.org
-
-open System
-
-[<EntryPoint>]
-let main argv = 
-    printfn "Hello World!"
-    printfn "%A" argv
-    0 // return an integer exit code

--- a/src/Chessie/paket.template
+++ b/src/Chessie/paket.template
@@ -19,3 +19,7 @@ summary
     Railway-oriented programming for .NET
 description
     Railway-oriented programming for .NET
+files
+    ../../bin/Chessie.* ==> lib/net40
+    bin/Release/dnxcore50/Chessie.dll ==> lib/dnxcore50
+    

--- a/src/Chessie/paket.template
+++ b/src/Chessie/paket.template
@@ -21,5 +21,3 @@ description
     Railway-oriented programming for .NET
 files
     ../../bin/Chessie.* ==> lib/net40
-    bin/Release/dnxcore50/Chessie.dll ==> lib/dnxcore50
-    

--- a/src/Chessie/project.json
+++ b/src/Chessie/project.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "compilerName": "fsc",
+    "compileFiles": [
+        "Program.fs"
+    ],
+
+    "dependencies": {
+        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+        "NETStandard.Library": "1.0.0-rc2-23811"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/src/Chessie/project.json
+++ b/src/Chessie/project.json
@@ -1,7 +1,6 @@
 {
     "version": "1.0.0-*",
     "compilationOptions": {
-        "emitEntryPoint": true
     },
 
     "compilerName": "fsc",

--- a/src/Chessie/project.json
+++ b/src/Chessie/project.json
@@ -1,5 +1,8 @@
 {
-    "version": "1.0.0-*",
+    "version": "0.4.0",
+    "authors": ["Steffen Forkmann", "Max Malook", "Tomasz Heimowski"],
+    "description": "Railway-oriented programming for .NET",
+    
     "compilationOptions": {
     },
 

--- a/src/Chessie/project.json
+++ b/src/Chessie/project.json
@@ -8,12 +8,12 @@
         "ErrorHandling.fs"
     ],
 
-    "dependencies": {
-        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
-        "NETStandard.Library": "1.0.0-rc2-23811"
-    },
-
     "frameworks": {
-        "dnxcore50": { }
+        "dnxcore50": { 
+            "dependencies": {
+                "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+                "NETStandard.Library": "1.0.0-rc2-23811"
+            }
+        }
     }
 }

--- a/src/Chessie/project.json
+++ b/src/Chessie/project.json
@@ -21,11 +21,15 @@
                 "FSharp.Core": "4.0.0.1"
              }
         },
-        "dnxcore50": { 
+        "netstandard1.5": { 
             "dependencies": {
                 "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
                 "NETStandard.Library": "1.0.0-rc2-23811"
-            }
+            },
+            "imports": [
+                "dnxcore50",
+                "portable-net45+win81"
+            ]
         }
     }
 }

--- a/src/Chessie/project.json
+++ b/src/Chessie/project.json
@@ -6,7 +6,7 @@
 
     "compilerName": "fsc",
     "compileFiles": [
-        "Program.fs"
+        "ErrorHandling.fs"
     ],
 
     "dependencies": {

--- a/src/Chessie/project.json
+++ b/src/Chessie/project.json
@@ -5,6 +5,10 @@
     
     "compilationOptions": {
     },
+    
+    "tools": {
+        "dotnet-mergenupkg": { "target": "package", "version": "0.9.*" }	
+    },
 
     "compilerName": "fsc",
     "compileFiles": [

--- a/src/Chessie/project.json
+++ b/src/Chessie/project.json
@@ -9,6 +9,11 @@
     ],
 
     "frameworks": {
+        "net46": {
+            "dependencies": {
+                "FSharp.Core": "4.0.0.1"
+             }
+        },
         "dnxcore50": { 
             "dependencies": {
                 "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",

--- a/tests/Chessie.CSharp.Test/NuGet.Config
+++ b/tests/Chessie.CSharp.Test/NuGet.Config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/tests/Chessie.CSharp.Test/Program.cs
+++ b/tests/Chessie.CSharp.Test/Program.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Reflection;
+
+namespace Chessie.CSharp.TestRunner
+{
+    public static class Program
+    {
+        public static int Main(string[] argv)
+        {
+#if DNXCORE50
+            var run = new NUnitLite.AutoRun(typeof(Program).GetTypeInfo().Assembly);
+            return run.Execute(argv, (new NUnit.Common.ExtendedTextWrapper(Console.Out)), Console.In);
+#else
+            var run = new NUnitLite.AutoRun();
+            return run.Execute(argv);
+#endif
+        }
+    }
+}

--- a/tests/Chessie.CSharp.Test/Program.cs
+++ b/tests/Chessie.CSharp.Test/Program.cs
@@ -7,7 +7,7 @@ namespace Chessie.CSharp.TestRunner
     {
         public static int Main(string[] argv)
         {
-#if DNXCORE50
+#if NETSTANDARD1_5
             var run = new NUnitLite.AutoRun(typeof(Program).GetTypeInfo().Assembly);
             return run.Execute(argv, (new NUnit.Common.ExtendedTextWrapper(Console.Out)), Console.In);
 #else

--- a/tests/Chessie.CSharp.Test/project.json
+++ b/tests/Chessie.CSharp.Test/project.json
@@ -1,0 +1,18 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "Chessie": { "target": "project", "type": "build", "version": "*" },
+        "NUnit": "3.2.0",
+        "NUnitLite": "3.2.0",
+        "NETStandard.Library": "1.0.0-rc2-23811"
+    },
+
+    "frameworks": {
+        "net46": { },
+        "dnxcore50": { }
+    }
+}

--- a/tests/Chessie.CSharp.Test/project.json
+++ b/tests/Chessie.CSharp.Test/project.json
@@ -7,12 +7,22 @@
     "dependencies": {
         "Chessie": { "target": "project", "type": "build", "version": "*" },
         "NUnit": "3.2.0",
-        "NUnitLite": "3.2.0",
-        "NETStandard.Library": "1.0.0-rc2-23811"
+        "NUnitLite": "3.2.0"
     },
 
     "frameworks": {
         "net46": { },
-        "dnxcore50": { }
+        "netstandard1.5": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.0.0-rc2-23925"
+                }
+            },
+            "imports": [
+                "dnxcore50",
+                "portable-net45+win81"
+            ]
+        }
     }
 }

--- a/tests/Chessie.Tests/NuGet.Config
+++ b/tests/Chessie.Tests/NuGet.Config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/tests/Chessie.Tests/Program.fs
+++ b/tests/Chessie.Tests/Program.fs
@@ -1,0 +1,17 @@
+﻿module Chessie.TestRunner
+
+open System
+open System.Reflection
+
+type Program = class end
+
+[<EntryPoint>]
+let main argv = 
+
+#if DNXCORE50
+    let run = typeof<Program>.GetTypeInfo().Assembly |> NUnitLite.AutoRun
+    run.Execute(argv, (new NUnit.Common.ExtendedTextWrapper(Console.Out)), Console.In)
+#else
+    let run = NUnitLite.AutoRun()
+    run.Execute(argv)
+#endif

--- a/tests/Chessie.Tests/Program.fs
+++ b/tests/Chessie.Tests/Program.fs
@@ -8,7 +8,7 @@ type Program = class end
 [<EntryPoint>]
 let main argv = 
 
-#if DNXCORE50
+#if NETSTANDARD1_5
     let run = typeof<Program>.GetTypeInfo().Assembly |> NUnitLite.AutoRun
     run.Execute(argv, (new NUnit.Common.ExtendedTextWrapper(Console.Out)), Console.In)
 #else

--- a/tests/Chessie.Tests/project.json
+++ b/tests/Chessie.Tests/project.json
@@ -1,6 +1,7 @@
 {
     "version": "1.0.0-*",
     "compilationOptions": {
+        "emitEntryPoint": true
     },
 
     "compilerName": "fsc",
@@ -9,12 +10,14 @@
         "TrialTests.fs",
         "BuilderTests.fs",
         "SimpleValidation.fs",
-        "NightClubs.fs"
+        "NightClubs.fs",
+        "Program.fs"
     ],
 
     "dependencies": {
         "Chessie": { "target": "project", "type": "build", "version": "*" },
-        "NUnit": "3.2.0"
+        "NUnit": "3.2.0",
+        "NUnitLite": "3.2.0"
     },
 
     "frameworks": {

--- a/tests/Chessie.Tests/project.json
+++ b/tests/Chessie.Tests/project.json
@@ -16,6 +16,7 @@
     "frameworks": {
         "net46": {
             "dependencies": {
+                "Chessie": { "target": "project", "type": "build", "version": "*" },
                 "NUnit": "3.2.0",
                 "FSharp.Core": "4.0.0.1"
             }

--- a/tests/Chessie.Tests/project.json
+++ b/tests/Chessie.Tests/project.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+    },
+
+    "compilerName": "fsc",
+    "compileFiles": [
+        "../../paket-files/test/forki/FsUnit/FsUnit.fs",
+        "TrialTests.fs",
+        "BuilderTests.fs",
+        "SimpleValidation.fs",
+        "NightClubs.fs"
+    ],
+
+
+    "frameworks": {
+        "net46": {
+            "NUnit": "3.2.0",
+            "FSharp.Core": "4.0.0.1"
+        },
+        "dnxcore50": { 
+            "dependencies": {
+                "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+                "NETStandard.Library": "1.0.0-rc2-23811"
+            }
+        }
+    }
+}

--- a/tests/Chessie.Tests/project.json
+++ b/tests/Chessie.Tests/project.json
@@ -26,11 +26,18 @@
                 "FSharp.Core": "4.0.0.1"
             }
         },
-        "dnxcore50": { 
+        "netstandard1.5": { 
             "dependencies": {
                 "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
-                "NETStandard.Library": "1.0.0-rc2-23811"
-            }
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.0.0-rc2-23925"
+                }
+            },
+            "imports": [
+                "dnxcore50",
+                "portable-net45+win81"
+            ]
         }
     }
 }

--- a/tests/Chessie.Tests/project.json
+++ b/tests/Chessie.Tests/project.json
@@ -23,6 +23,8 @@
         },
         "dnxcore50": { 
             "dependencies": {
+                "Chessie": { "target": "project", "type": "build", "version": "*" },
+                "NUnit": "3.2.0",
                 "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
                 "NETStandard.Library": "1.0.0-rc2-23811"
             }

--- a/tests/Chessie.Tests/project.json
+++ b/tests/Chessie.Tests/project.json
@@ -12,19 +12,19 @@
         "NightClubs.fs"
     ],
 
+    "dependencies": {
+        "Chessie": { "target": "project", "type": "build", "version": "*" },
+        "NUnit": "3.2.0"
+    },
 
     "frameworks": {
         "net46": {
             "dependencies": {
-                "Chessie": { "target": "project", "type": "build", "version": "*" },
-                "NUnit": "3.2.0",
                 "FSharp.Core": "4.0.0.1"
             }
         },
         "dnxcore50": { 
             "dependencies": {
-                "Chessie": { "target": "project", "type": "build", "version": "*" },
-                "NUnit": "3.2.0",
                 "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
                 "NETStandard.Library": "1.0.0-rc2-23811"
             }

--- a/tests/Chessie.Tests/project.json
+++ b/tests/Chessie.Tests/project.json
@@ -15,8 +15,10 @@
 
     "frameworks": {
         "net46": {
-            "NUnit": "3.2.0",
-            "FSharp.Core": "4.0.0.1"
+            "dependencies": {
+                "NUnit": "3.2.0",
+                "FSharp.Core": "4.0.0.1"
+            }
         },
         "dnxcore50": { 
             "dependencies": {


### PR DESCRIPTION
from: https://plus.google.com/events/c6tik5o4aofom0s2numam7nc57c

I updated nunit to version 3.
nunit projects now are executable in project.json (fsproj are not changed) with nunit runner, you just need to run it (xplat works!)

the dotnet build expect the `paket-files/test/forki/FsUnit/FsUnit.fs` already downloaded
