### PR TITLE
use correct version in project.json

### DIFF
--- a/src/Chessie/project.json
+++ b/src/Chessie/project.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.4.0",
+    "version": "0.5.0",
     "authors": ["Steffen Forkmann", "Max Malook", "Tomasz Heimowski"],
     "description": "Railway-oriented programming for .NET",
     


### PR DESCRIPTION
the package version should be changed also in project.json

it's not possibile yet to change the whole version ( ref https://github.com/dotnet/cli/issues/571 ), only to add a version suffix

And i cannot creatively use the `version-suffix` in `dotnet pack` because version `*`, `0.*` are not a valid version string, so i cannot pass only one part of the version.
