### PR TITLE
Add Kleisli composition operator

### DIFF
--- a/src/Chessie/ErrorHandling.fs
+++ b/src/Chessie/ErrorHandling.fs
@@ -100,6 +100,9 @@ module Trial =
     /// This is the infix operator version of ErrorHandling.bind
     let inline (>>=) result f = bind f result
 
+    /// Infix operator of Kleisli composition of functions f and g.
+    let inline (>=>) f g = f >> (bind g)
+
     /// If the wrapped function is a success and the given result is a success the function is applied on the value. 
     /// Otherwise the exisiting error messages are propagated.
     let inline apply wrappedFunction result = 


### PR DESCRIPTION
`>=>` is commonly used to compose two functions (e.g. `f` and `g`) that each return a monadic value.

It is also in [Scott's ROP article](http://fsharpforfunandprofit.com/posts/recipe-part2/)
