### PR TITLE
add Combine method to AsyncTrialBuilder

### DIFF
--- a/src/Chessie/ErrorHandling.fs
+++ b/src/Chessie/ErrorHandling.fs
@@ -285,6 +285,9 @@ module AsyncTrial =
             |> Async.bind (binder >> Async.ofAsyncResult)
             |> AR
         
+        member this.Combine (asyncResult1 : AsyncResult<unit, 'c>, asyncResult2 : AsyncResult<'a, 'c>) =
+            this.Bind (asyncResult1, fun () -> asyncResult2)
+
         member __.TryWith(asyncResult : AsyncResult<'a, 'b>, catchHandler : exn -> AsyncResult<'a, 'b>) : AsyncResult<'a, 'b> = 
             async.TryWith(asyncResult |> Async.ofAsyncResult, (catchHandler >> Async.ofAsyncResult)) |> AR
         member __.TryFinally(asyncResult : AsyncResult<'a, 'b>, compensation : unit -> unit) : AsyncResult<'a, 'b> = 


### PR DESCRIPTION
Added a `Combine` method to the `AsyncTrialBilder` required for match-with and if-then-else expressions within the `asyncTrial` computation expression.